### PR TITLE
[i15] Implement Redis Database with Docker and Create Go Application Interface

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,8 @@ services:
   postgres:
     image: postgres:17
     container_name: postgres
-    
+    restart: unless-stopped
+
     environment: 
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -16,8 +17,9 @@ services:
 
 
   pgadmin:
-    image: dpage/pgadmin4:8.14.0
+    image: dpage/pgadmin4:latest
     container_name: pgadmin
+    restart: unless-stopped
 
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
@@ -29,6 +31,34 @@ services:
     volumes:
       - pgadmin_data:/var/lib/pgadmin
 
+
+  redis:
+    image: redis:7.4.2
+    container_name: redis
+    restart: unless-stopped
+
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+
+    command:  ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
+
+    ports:
+      - "6379:6379"
+
+    volumes:
+      - redis_data:/data
+
+
+  redisinsight:
+    image: redis/redisinsight:latest
+    container_name: auth_redisinsight
+    restart: unless-stopped
+    
+    ports:
+      - "5540:5540"
+
 volumes:
   postgres_data:
   pgadmin_data:
+
+  redis_data:

--- a/docker/examle.env.txt
+++ b/docker/examle.env.txt
@@ -1,5 +1,8 @@
 POSTGRES_USER="admin"
 POSTGRES_PASSWORD="password"
 POSTGRES_DB="auth_service"
+
 PGADMIN_DEFAULT_EMAIL="admin@admin.com"
 PGADMIN_DEFAULT_PASSWORD="password"
+
+REDIS_PASSWORD="password"

--- a/example.env
+++ b/example.env
@@ -8,3 +8,6 @@ POSTGRES_HOST="localhost"
 POSTGRES_PORT="5432"
 POSTGRES_DBNAME="auth_service"
 POSTGRES_SSLMODE="disable
+
+REDIS_ADDRESS="localhost:6379"
+REDIS_PASSWORD="password"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,9 @@ go 1.23.5
 require github.com/rs/zerolog v1.33.0
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
+github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	db_postgresSQL "cerberus/internal/database/postgresSQL"
+	db_redis "cerberus/internal/database/redis"
 	logger "cerberus/internal/tools"
 	"cerberus/pkg/config"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 // Currently, it only contains a connection to a PostgreSQL database.
 type Databases struct {
 	Postgres *gorm.DB
+	Redis    *db_redis.RedisPack
 }
 
 // InitDatabases initializes database connections based on the provided configuration.
@@ -39,7 +41,14 @@ func InitDatabases(p_config *config.ConfigData) (*Databases, error) {
 		return nil, err
 	}
 
+	rdb, err := db_redis.ConnectRedis(p_config)
+	if err != nil {
+		logger.Log(fmt.Sprintf("Failed to connect to redis: %s", err.Error()), logger.ERROR)
+		return nil, err
+	}
+
 	return &Databases{
 		Postgres: pdb,
+		Redis:    rdb,
 	}, nil
 }

--- a/internal/database/redis/db.go
+++ b/internal/database/redis/db.go
@@ -9,11 +9,24 @@ import (
 	"github.com/go-redis/redis/v8"
 )
 
+// RedisPack encapsulates a Redis client and its associated context.
 type RedisPack struct {
 	Client *redis.Client
 	Ctx    context.Context
 }
 
+// ConnectRedis establishes a connection to Redis using the provided configuration.
+// It creates a new RedisPack with a Redis client and a background context.
+//
+// Parameters:
+//   - p_cfg: A pointer to the ConfigData structure containing Redis connection details.
+//
+// Returns:
+//   - *RedisPack: A pointer to the created RedisPack if the connection is successful.
+//   - error: An error if the connection fails, nil otherwise.
+//
+// The function attempts to ping the Redis server to verify the connection.
+// It logs the connection status and returns an error if the connection fails.
 func ConnectRedis(p_cfg *config.ConfigData) (*RedisPack, error) {
 	var pack RedisPack = RedisPack{
 		Ctx: context.Background(),

--- a/internal/database/redis/db.go
+++ b/internal/database/redis/db.go
@@ -1,0 +1,38 @@
+package db_redis
+
+import (
+	logger "cerberus/internal/tools"
+	"cerberus/pkg/config"
+	"context"
+	"errors"
+
+	"github.com/go-redis/redis/v8"
+)
+
+type RedisPack struct {
+	Client *redis.Client
+	Ctx    context.Context
+}
+
+func ConnectRedis(p_cfg *config.ConfigData) (*RedisPack, error) {
+	var pack RedisPack = RedisPack{
+		Ctx: context.Background(),
+	}
+	pack.Client = redis.NewClient(&redis.Options{
+		Addr:     p_cfg.RedisData.Address,
+		Password: p_cfg.RedisData.Password,
+		DB:       0,
+	})
+
+	_, err := pack.Client.Ping(pack.Ctx).Result()
+	if err != nil {
+		msg := "Failed to connect to Redis - " + err.Error()
+		logger.Log(msg, logger.ERROR)
+
+		return nil, errors.New(msg)
+	}
+
+	logger.Log("🧲 Connected to redis successfully", logger.INFO)
+	return &pack, nil
+
+}

--- a/internal/handlers/hello_world_route.go
+++ b/internal/handlers/hello_world_route.go
@@ -1,9 +1,0 @@
-package handlers
-
-import (
-	"net/http"
-)
-
-func HelloWorldHandler(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("Hello World"))
-}

--- a/internal/routes/auth_routes.go
+++ b/internal/routes/auth_routes.go
@@ -2,7 +2,6 @@ package routes
 
 import (
 	"cerberus/internal/database"
-	"cerberus/internal/handlers"
 	auth_handler "cerberus/internal/handlers/auth"
 	md "cerberus/internal/middleware"
 	logger "cerberus/internal/tools"
@@ -29,10 +28,6 @@ func SetupAuthRoutes(p_mux *http.ServeMux, p_cfg *config.ConfigData, p_dbs *data
 		md.TimeRequestMiddleware, md.CORSMiddleware(p_cfg), md.LogRequestMiddleware)
 
 	return []*Route{
-		NewRoute(p_mux, "/hello",
-			http.HandlerFunc(handlers.HelloWorldHandler),
-			md.TimeRequestMiddleware, md.CORSMiddleware(p_cfg), md.LogRequestMiddleware),
-
 		authGroup.NewRoute("/register", auth_handler.CreateRegisterHandler(p_dbs),
 			md.PostMethodCheckMiddleware),
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,10 +42,10 @@ func Start() {
 		return
 	}
 
+	// Define routes
 	routes.SetupRoutes(mux, cfg, dbs)
 
 	logger.Log(fmt.Sprintf("🍭 Starting server at %s", cfg.GetAddressStr()), logger.INFO)
-
 	// Start the HTTP server
 	if err := http.ListenAndServe(cfg.GetAddressStr(), mux); err != nil {
 		logger.Log(fmt.Sprintf("💥 Error during serving - %s", err), logger.INFO)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,6 +111,7 @@ func LoadEnvFile(p_path string) (*ConfigData, error) {
 
 			default:
 				cfg.PostgresData.ParseLineData(key, value)
+				cfg.RedisData.ParseLineData(key, value)
 			}
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,8 @@ package config
 import (
 	"bufio"
 	logger "cerberus/internal/tools"
-	postgres_config "cerberus/pkg/config/db"
+	db_config "cerberus/pkg/config/db"
+
 	"errors"
 	"fmt"
 	"os"
@@ -21,7 +22,8 @@ type ConfigData struct {
 	EnableCORS     bool
 	AllowedOrigins []string
 
-	PostgresData postgres_config.ConfigData
+	PostgresData db_config.PostgresConfigData
+	RedisData    db_config.RedisConfigData
 }
 
 // DefaultCfg is the default configuration that is loaded at initialization.
@@ -34,7 +36,8 @@ func init() {
 
 	DefaultCfg.EnableCORS = true
 	DefaultCfg.AllowedOrigins = make([]string, 0)
-	DefaultCfg.PostgresData = postgres_config.DefaultCfg
+	DefaultCfg.PostgresData = db_config.DefaultPostgresCfg
+	DefaultCfg.RedisData = db_config.DefaultRedisConfig
 }
 
 // region Public

--- a/pkg/config/db/postgress_config.go
+++ b/pkg/config/db/postgress_config.go
@@ -55,7 +55,6 @@ func (cfg *PostgresConfigData) ParseLineData(p_key string, p_value string) {
 
 	if f, ok := fMap[p_key]; ok {
 		*f = p_value
-		return
 	}
 }
 

--- a/pkg/config/db/postgress_config.go
+++ b/pkg/config/db/postgress_config.go
@@ -1,26 +1,26 @@
-package postgres_config
+package db_config
 
 import (
 	"fmt"
 	"os"
 )
 
-// ConfigData represents the configuration data for a database connection.
+// PostgresConfigData represents the configuration data for a database connection.
 //
 // This struct holds the necessary information to establish a connection
 // to a database server, typically PostgreSQL.
-type ConfigData struct {
+type PostgresConfigData struct {
 	Host    string // The hostname or IP address of the database server
 	Port    string // The port number on which the database server is listening
 	DbName  string // The name of the database to connect to
 	SslMode string // The SSL mode for the connection (e.g., "disable", "require", "verify-full")
 }
 
-// DefaultCfg is a global variable that holds default configuration values.
+// DefaultPostgresCfg is a global variable that holds default configuration values.
 //
 // It is initialized with preset values in the init() function and can be used
 // as a fallback or starting point for database configurations.
-var DefaultCfg ConfigData
+var DefaultPostgresCfg PostgresConfigData
 
 // init initializes the DefaultCfg with preset values.
 //
@@ -28,10 +28,10 @@ var DefaultCfg ConfigData
 // It sets up default values for the database configuration, which can be
 // overridden later if needed.
 func init() {
-	DefaultCfg.Host = "localhost"
-	DefaultCfg.Port = "8080"
-	DefaultCfg.DbName = "db"
-	DefaultCfg.SslMode = "disable"
+	DefaultPostgresCfg.Host = "localhost"
+	DefaultPostgresCfg.Port = "8080"
+	DefaultPostgresCfg.DbName = "db"
+	DefaultPostgresCfg.SslMode = "disable"
 }
 
 // region Public
@@ -45,7 +45,7 @@ func init() {
 // Parameters:
 //   - p_key: A string representing the configuration key.
 //   - p_value: A string representing the value for the given key.
-func (cfg *ConfigData) ParseLineData(p_key string, p_value string) {
+func (cfg *PostgresConfigData) ParseLineData(p_key string, p_value string) {
 	fMap := map[string]*string{
 		"POSTGRES_HOST":    &cfg.Host,
 		"POSTGRES_PORT":    &cfg.Port,
@@ -70,7 +70,7 @@ func (cfg *ConfigData) ParseLineData(p_key string, p_value string) {
 // Environment Variables Used:
 //   - POSTGRES_USERNAME: The PostgreSQL username.
 //   - POSTGRES_PASSWORD: The PostgreSQL password.
-func (cfg *ConfigData) GetDsn() string {
+func (cfg *PostgresConfigData) GetDsn() string {
 	var usr string = os.Getenv("POSTGRES_USERNAME")
 	var pwd string = os.Getenv("POSTGRES_PASSWORD")
 

--- a/pkg/config/db/redis_config.go
+++ b/pkg/config/db/redis_config.go
@@ -1,13 +1,32 @@
 package db_config
 
+// RedisConfigData represents the configuration data for a Redis connection.
 type RedisConfigData struct {
 	Address  string
 	Password string
 }
 
+// DefaultRedisConfig is a global variable holding the default Redis configuration.
 var DefaultRedisConfig RedisConfigData
 
 func init() {
 	DefaultRedisConfig.Address = "localhost:6379"
 	DefaultRedisConfig.Password = ""
+}
+
+// ParseLineData parses a key-value pair and updates the corresponding field in the RedisConfigData struct.
+// It matches the key against predefined fields and updates the matching field with the provided value.
+//
+// Parameters:
+//   - p_key: A string representing the configuration key.
+//   - p_value: A string representing the value to be set for the given key.
+func (cfg *RedisConfigData) ParseLineData(p_key string, p_value string) {
+	fMap := map[string]*string{
+		"REDIS_ADDRESS":  &cfg.Address,
+		"REDIS_PASSWORD": &cfg.Password,
+	}
+
+	if f, ok := fMap[p_key]; ok {
+		*f = p_value
+	}
 }

--- a/pkg/config/db/redis_config.go
+++ b/pkg/config/db/redis_config.go
@@ -1,0 +1,13 @@
+package db_config
+
+type RedisConfigData struct {
+	Address  string
+	Password string
+}
+
+var DefaultRedisConfig RedisConfigData
+
+func init() {
+	DefaultRedisConfig.Address = "localhost:6379"
+	DefaultRedisConfig.Password = ""
+}


### PR DESCRIPTION
Setting up a Redis database using Docker and creating a Go application interface to interact with it. The Docker setup will utilize the official Redis image to create a containerized instance, configuring it with appropriate network settings and persistent storage. The Redis container will expose the default port (6379) for external connections, ensuring accessibility from the Go application.

The Go application interface will be built using the go-redis library, providing functions for common Redis operations such as SET, GET, and others. The implementation will include error handling and connection management to ensure robustness. Additionally, a connection pool will be implemented for efficient Redis client management, and logging capabilities will be added to monitor Redis connections. This setup will provide a flexible and scalable solution for integrating Redis into Go applications.