### PR TITLE
[i20] Implement Refresh JWT Endpoint for Secure Token Renewal

### DIFF
--- a/internal/dto/session_dto/refresh_dto.go
+++ b/internal/dto/session_dto/refresh_dto.go
@@ -1,0 +1,22 @@
+package session_dto
+
+// RefreshRequest represents the request payload for refreshing an access token.
+// It contains the refresh token used to generate a new access token.
+type RefreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+// RefreshData holds the data generated during the token refresh process.
+// It includes the new access token and refresh token.
+type RefreshData struct {
+	AccessToken  string
+	RefreshToken string
+}
+
+// RefreshResponse represents the response payload returned after a successful token refresh.
+// It includes a success message, the new access token, and the new refresh token.
+type RefreshResponse struct {
+	Message      string `json:"message"`
+	Token        string `json:"token"`
+	RefreshToken string `json:"refresh_token"`
+}

--- a/internal/handlers/session/login_handler.go
+++ b/internal/handlers/session/login_handler.go
@@ -50,7 +50,7 @@ func CreateLoginHandler(p_db *database.DataRefs) http.HandlerFunc {
 			return
 		}
 
-		services.RevokeAllSessionTokensToUser(p_db.Redis, usr)
+		services.RevokeAllSessionTokensToUser(p_db.Redis, usr.ID.String())
 
 		loginData, err := services.LoginUser(p_db, usr)
 		if err != nil {

--- a/internal/handlers/session/logout_handler.go
+++ b/internal/handlers/session/logout_handler.go
@@ -58,7 +58,7 @@ func CreateLogoutHandler(p_db *database.DataRefs) http.HandlerFunc {
 			return
 		}
 
-		services.RevokeAllSessionTokensToUser(p_db.Redis, usr)
+		services.RevokeAllSessionTokensToUser(p_db.Redis, usr.ID.String())
 		res := session_dto.LogoutResponse{
 			Message: "Logged out successfully",
 		}

--- a/internal/handlers/session/refresh_handler.go
+++ b/internal/handlers/session/refresh_handler.go
@@ -1,0 +1,20 @@
+package session_handler
+
+import (
+	"cerberus/internal/database"
+	"cerberus/internal/middleware"
+	"cerberus/internal/tools/logger"
+	"net/http"
+)
+
+func CreateRefreshHandler(p_db *database.DataRefs) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tkn := r.Context().Value(middleware.JWTToken("token"))
+
+		if tkn == nil || tkn == "" {
+			logger.Log("Invalid token - ", logger.ERROR)
+			http.Error(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+	})
+}

--- a/internal/handlers/session/refresh_handler.go
+++ b/internal/handlers/session/refresh_handler.go
@@ -2,11 +2,23 @@ package session_handler
 
 import (
 	"cerberus/internal/database"
+	"cerberus/internal/dto/session_dto"
 	"cerberus/internal/middleware"
+	"cerberus/internal/services"
 	"cerberus/internal/tools/logger"
+	"encoding/json"
 	"net/http"
 )
 
+// CreateRefreshHandler returns an HTTP handler function for refreshing session tokens.
+// It validates the provided JWT token and refresh token, revokes all existing session tokens for the user,
+// generates new tokens, and returns them in the response.
+//
+// Parameters:
+//   - p_db: A pointer to the database.DataRefs struct containing database references.
+//
+// Returns:
+//   - http.HandlerFunc: The HTTP handler function that processes the refresh token request.
 func CreateRefreshHandler(p_db *database.DataRefs) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tkn := r.Context().Value(middleware.JWTToken("token"))
@@ -16,5 +28,52 @@ func CreateRefreshHandler(p_db *database.DataRefs) http.HandlerFunc {
 			http.Error(w, "Invalid token", http.StatusUnauthorized)
 			return
 		}
+
+		var req session_dto.RefreshRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			logger.Log("Invalid request, failed to decode body - "+err.Error(), logger.ERROR)
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
+
+		sTkn, ok := tkn.(string)
+		if !ok {
+			logger.Log("Invalid token", logger.ERROR)
+			http.Error(w, "Failed to parse token", int(logger.ERROR))
+			return
+		}
+
+		usr_id, err := p_db.JWTGen.GetUserIDFromToken(sTkn)
+		if err != nil {
+			logger.Log("Failed to get userId - "+err.Error(), logger.ERROR)
+			http.Error(w, "Failed to get userId", http.StatusUnauthorized)
+
+		}
+
+		valid, err := services.ValidateRefreshToken(p_db, usr_id, req.RefreshToken)
+		if err != nil || !valid {
+			logger.Log("Invalid refresh token", logger.ERROR)
+			http.Error(w, "Invalid or expired refresh token", http.StatusUnauthorized)
+			return
+		}
+		services.RevokeAllSessionTokensToUser(p_db.Redis, usr_id)
+
+		loginData, err := services.GenerateTokensAndSave(p_db, usr_id)
+		if err != nil {
+			logger.Log("Failed to generate tokens", logger.ERROR)
+			http.Error(w, "Failed to generate tokens", http.StatusUnauthorized)
+			return
+		}
+
+		res := session_dto.RefreshResponse{
+			Message:      "Refreshed tokens",
+			Token:        loginData.AccessToken,
+			RefreshToken: loginData.RefreshToken,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(res)
+
 	})
 }

--- a/internal/routes/session_routes.go
+++ b/internal/routes/session_routes.go
@@ -37,5 +37,8 @@ func SetupSessionRoutes(p_mux *http.ServeMux, p_cfg *config.ConfigData, p_dgs *d
 
 		sessionGroup.NewRoute("/validate", session_handler.CreateValidateHandler(p_dgs),
 			md.PostMethodCheckMiddleware, md.AuthenticationHeaderMiddleware),
+
+		sessionGroup.NewRoute("/refresh", session_handler.CreateRefreshHandler(p_dgs),
+			md.PostMethodCheckMiddleware, md.AuthenticationHeaderMiddleware),
 	}
 }

--- a/internal/tools/jwt/jwt_utils.go
+++ b/internal/tools/jwt/jwt_utils.go
@@ -116,3 +116,20 @@ func (gen *JWTGenerator) GenerateRefreshToken() (string, error) {
 func (gen *JWTGenerator) ValidateRefreshToken(p_savedToken string, p_targetToken string) bool {
 	return p_savedToken == p_targetToken
 }
+
+// GetUserIDFromToken extracts the user ID from the provided JWT token.
+// It parses the token using the JWT secret stored in the JWTGenerator instance
+// and validates the token's signature. If the token is valid, it returns the user ID
+// embedded in the token. If the token is invalid or parsing fails, it returns an error.
+func (gen *JWTGenerator) GetUserIDFromToken(p_token string) (string, error) {
+	claims := &Claims{}
+
+	_, err := jwt.ParseWithClaims(p_token, claims, func(t *jwt.Token) (interface{}, error) {
+		return gen.Secret, nil
+	})
+	if err != nil {
+		return "", errors.New("invalid token")
+	}
+
+	return claims.UserID, nil
+}


### PR DESCRIPTION
This merge request introduces the implementation of a refresh JWT endpoint, enabling users to renew their authentication tokens seamlessly without requiring re-login. The endpoint accepts a valid refresh token, verifies its authenticity and expiration, and issues a new JWT and refresh token pair. Key features include robust token validation, comprehensive error handling for invalid or expired tokens, and secure storage and invalidation of refresh tokens to prevent misuse. Logging mechanisms are also implemented to track token renewal events for auditing and monitoring purposes.

The implementation has been thoroughly tested to ensure reliability, covering scenarios such as token reuse, expiration, and invalid requests. This enhancement improves user experience by maintaining uninterrupted access to the application while adhering to strict security standards. The changes align with the broader goal of ensuring secure and efficient authentication workflows.